### PR TITLE
Add TinyTools — Color Palette + Favicon + OG Image generators to Design Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Know a cool tool that's not listed? [Create a PR](../../pulls) or [message me on
 - [SVG Loaders](https://magecdn.com/tools/svg-loaders?utm_source=awesome-ai-tools-for-ui) - 100+ open-source animated SVG loading spinners (MIT).
 - [SVG Backgrounds](https://www.svgbackgrounds.com/set/free-svg-backgrounds-and-patterns/?utm_source=awesome-ai-tools-for-ui) - Free SVG backgrounds and patterns you can customize.
 - [Realtime Colors](https://www.realtimecolors.com/?utm_source=awesome-ai-tools-for-ui) - Preview color palettes and typography on a live website mockup.
+- [TinyTools Color Palette Generator](https://tinytools-smoky.vercel.app/?utm_source=awesome-ai-tools-for-ui) - Generate harmonious color palettes (complementary, analogous, triadic) with hex/RGB/HSL output. Free, runs in the browser, no signup.
+- [TinyTools Favicon Generator](https://tinytools-smoky.vercel.app/?utm_source=awesome-ai-tools-for-ui) - Convert any image into a multi-resolution favicon pack (16×16, 32×32, 180×180, 192×192, 512×512) with web manifest. Browser-based, no upload to a server.
+- [TinyTools OG Image Generator](https://tinytools-smoky.vercel.app/?utm_source=awesome-ai-tools-for-ui) - Generate Open Graph / Twitter card images (1200×630) with custom typography, gradients, and layouts. Exports PNG, no signup.
 
 ## Resources
 


### PR DESCRIPTION
Hi! Thanks for maintaining this list — the Design Tools section's "Not AI-powered, but valuable tools for UI/UX work" framing is a great fit for what I'd like to add.

I'm proposing three single-purpose, browser-based generators from [TinyTools](https://tinytools-smoky.vercel.app/) that fit alongside Realtime Colors, FontCrafter, SVG Backgrounds, etc.:

- **Color Palette Generator** — harmonies (complementary, analogous, triadic) with hex/RGB/HSL output
- **Favicon Generator** — image → multi-resolution favicon pack with web manifest
- **OG Image Generator** — 1200×630 Open Graph / Twitter card images, exports PNG

All are free, run in the browser, and require no signup — same low-friction pattern as the existing Design Tools entries. UTM tag is set to  so you can track clicks. Happy to tweak wording or split into a single combined entry if preferred.