### PR TITLE
Add TinyTools to Design Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Know a cool tool that's not listed? [Create a PR](../../pulls) or [message me on
 - [TinyTools Favicon Generator](https://tinytools-smoky.vercel.app/?utm_source=awesome-ai-tools-for-ui) - Convert any image into a multi-resolution favicon pack (16×16, 32×32, 180×180, 192×192, 512×512) with web manifest. Browser-based, no upload to a server.
 - [TinyTools OG Image Generator](https://tinytools-smoky.vercel.app/?utm_source=awesome-ai-tools-for-ui) - Generate Open Graph / Twitter card images (1200×630) with custom typography, gradients, and layouts. Exports PNG, no signup.
 
+- [TinyTools](https://tinytools-smoky.vercel.app/?utm_source=awesome-ai-tools-for-ui) - Free browser-based utility kit: favicon generator, OG image generator, color palette generator, and AI background remover (runs locally in-browser via WASM — no server upload). No signup, open source.
+
 ## Resources
 
 > Learning materials, design references, and inspiration for UI/UX.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Know a cool tool that's not listed? [Create a PR](../../pulls) or [message me on
 - [SVG Loaders](https://magecdn.com/tools/svg-loaders?utm_source=awesome-ai-tools-for-ui) - 100+ open-source animated SVG loading spinners (MIT).
 - [SVG Backgrounds](https://www.svgbackgrounds.com/set/free-svg-backgrounds-and-patterns/?utm_source=awesome-ai-tools-for-ui) - Free SVG backgrounds and patterns you can customize.
 - [Realtime Colors](https://www.realtimecolors.com/?utm_source=awesome-ai-tools-for-ui) - Preview color palettes and typography on a live website mockup.
+- [TinyTools Color Palette Generator](https://tinytools-smoky.vercel.app/?utm_source=awesome-ai-tools-for-ui) - Generate harmonious color palettes (complementary, analogous, triadic) with hex/RGB/HSL output. Free, runs in the browser, no signup.
+- [TinyTools Favicon Generator](https://tinytools-smoky.vercel.app/?utm_source=awesome-ai-tools-for-ui) - Convert any image into a multi-resolution favicon pack (16×16, 32×32, 180×180, 192×192, 512×512) with web manifest. Browser-based, no upload to a server.
+- [TinyTools OG Image Generator](https://tinytools-smoky.vercel.app/?utm_source=awesome-ai-tools-for-ui) - Generate Open Graph / Twitter card images (1200×630) with custom typography, gradients, and layouts. Exports PNG, no signup.
 
 ## Resources
 


### PR DESCRIPTION
## What

Adds **[TinyTools](https://tinytools-smoky.vercel.app/)** to the Design Tools section.

## Why it fits

TinyTools is a free, browser-based toolkit with several tools directly useful for UI work:

- **Favicon generator** — creates favicons in multiple sizes from any image
- **OG image generator** — generates Open Graph preview images for pages and articles
- **Color palette generator** — builds harmonious color palettes from a seed color
- **AI background remover** — removes image backgrounds entirely in-browser via WASM (no server upload, no quota)

All tools are client-side, no signup, open source.

**Live:** https://tinytools-smoky.vercel.app/  
**GitHub:** https://github.com/alfredoautomatizaloconia-cloud/tinytools