### PR TITLE
Add ux-skill to Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Know a cool tool that's not listed? [Create a PR](../../pulls) or [message me on
 - [Bencium Marketplace](https://github.com/bencium/bencium-marketplace?utm_source=awesome-ai-tools-for-ui) - Claude Code plugin marketplace with skills for design, architecture, productivity, typography, and code review.
 - [Three.js Skills](https://github.com/CloudAI-X/threejs-skills?utm_source=awesome-ai-tools-for-ui) - Collection of Three.js skills covering scenes, geometry, lighting, shaders, loaders, animation, and interaction.
 - [Awesome DESIGN.md](https://github.com/VoltAgent/awesome-design-md/?utm_source=awesome-ai-tools-for-ui) - Curated collection of DESIGN.md files inspired by developer-focused websites.
+- [ux-skill](https://github.com/Laith0003/ux-skill) - Design-intelligence engine for 17 AI coding tools. Runs a 152-rule anti-slop linter, applies 160 brand specs, and generates frontend code from a structured brief. Deterministic, offline, MIT.
 
 ## Apps
 


### PR DESCRIPTION
## What this adds

Adds [ux-skill](https://github.com/Laith0003/ux-skill) to the **Skills** section.

ux-skill is a design-intelligence engine for 17 AI coding tools (Claude Code, Cursor, Windsurf, and more). It ships a 152-rule anti-slop linter, 160 brand specs, a 7-axis synthesizer, and a full MCP server (18 tools). It runs offline and deterministically — no LLM calls, no API keys. MIT licensed. `pip install uxskill`.

It belongs in the Skills section alongside Impeccable, Taste Skill, and the Anthropic frontend-design skill. All of them solve the same problem: stopping AI coding tools from producing generic-looking UI. ux-skill approaches it as a full design-intelligence layer — brief intake, design system generation, then deterministic linting before commit.

The entry follows the existing format (linked name, one-line description, no UTM). No other files changed.