### PR TITLE
feat: add TWZRD Agent Intel MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Know a cool tool that's not listed? [Create a PR](../../pulls) or [message me on
 - [Lazyweb](https://www.lazyweb.com/?utm_source=awesome-ai-tools-for-ui) - MCP server and skills that help agents research real app screens before designing UI.
 - [Design and Refine](https://github.com/0xdesign/design-plugin?utm_source=awesome-ai-tools-for-ui) - Claude Code plugin for generating, comparing, and refining multiple UI variations in your codebase.
 - [Interface Design](https://github.com/Dammyjay93/interface-design?utm_source=awesome-ai-tools-for-ui) - Claude Code plugin for remembering interface decisions across sessions and keeping UI systems consistent.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring for AI agent wallets on Solana. Verify agent identity before x402 micropayments. Free MCP: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 
 ## Design Tools
 


### PR DESCRIPTION
## What

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **MCP Servers & Plugins** section.

## Why

TWZRD Agent Intel is an MCP server providing trust scoring for AI agent wallets on Solana. It's directly relevant for UI/design AI agents that make x402 micropayments (e.g. purchasing UI component generation services, fonts, or design assets). The `score_agent` and `preflight_check` tools are free; `get_trust_receipt` uses x402 micropayment.

**MCP config:**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```