### PR TITLE
Add StyleSeed to Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Know a cool tool that's not listed? [Create a PR](../../pulls) or [message me on
 - [Bencium Marketplace](https://github.com/bencium/bencium-marketplace?utm_source=awesome-ai-tools-for-ui) - Claude Code plugin marketplace with skills for design, architecture, productivity, typography, and code review.
 - [Three.js Skills](https://github.com/CloudAI-X/threejs-skills?utm_source=awesome-ai-tools-for-ui) - Collection of Three.js skills covering scenes, geometry, lighting, shaders, loaders, animation, and interaction.
 - [Awesome DESIGN.md](https://github.com/VoltAgent/awesome-design-md/?utm_source=awesome-ai-tools-for-ui) - Curated collection of DESIGN.md files inspired by developer-focused websites.
-- [StyleSeed](https://github.com/bitjaru/styleseed?utm_source=awesome-ai-tools-for-ui) - Design rules and slash-command skills that give Claude Code, Cursor, and Codex design judgment — coherence, hierarchy, UX-writing — so AI-built UI stops looking generated.
+- [StyleSeed](https://github.com/bitjaru/styleseed?utm_source=awesome-ai-tools-for-ui) - Design rules and slash-command skills that give agents design judgment — coherence, hierarchy, UX-writing.
 
 ## Apps
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Know a cool tool that's not listed? [Create a PR](../../pulls) or [message me on
 - [Bencium Marketplace](https://github.com/bencium/bencium-marketplace?utm_source=awesome-ai-tools-for-ui) - Claude Code plugin marketplace with skills for design, architecture, productivity, typography, and code review.
 - [Three.js Skills](https://github.com/CloudAI-X/threejs-skills?utm_source=awesome-ai-tools-for-ui) - Collection of Three.js skills covering scenes, geometry, lighting, shaders, loaders, animation, and interaction.
 - [Awesome DESIGN.md](https://github.com/VoltAgent/awesome-design-md/?utm_source=awesome-ai-tools-for-ui) - Curated collection of DESIGN.md files inspired by developer-focused websites.
+- [StyleSeed](https://github.com/bitjaru/styleseed?utm_source=awesome-ai-tools-for-ui) - Design rules and slash-command skills that give Claude Code, Cursor, and Codex design judgment — coherence, hierarchy, UX-writing — so AI-built UI stops looking generated.
 
 ## Apps
 


### PR DESCRIPTION
Adds **StyleSeed** to the Skills section.

[StyleSeed](https://github.com/bitjaru/styleseed) is an open-source (MIT) design engine for Claude Code, Cursor, and Codex: 74 design rules + UX-writing rules + 15 `/ss-*` skills that give the agent design judgment (coherence, hierarchy, one-accent discipline) so AI-built UI stops looking generated. It ships CLAUDE.md / AGENTS.md / .cursorrules, so it works across agents.

Fits right alongside the other design-rule skills in the list. Thanks for maintaining this!