### PR TITLE
Add UIZZE MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Know a cool tool that's not listed? [Create a PR](../../pulls) or [message me on
 - [Lazyweb](https://www.lazyweb.com/?utm_source=awesome-ai-tools-for-ui) - MCP server and skills that help agents research real app screens before designing UI.
 - [Design and Refine](https://github.com/0xdesign/design-plugin?utm_source=awesome-ai-tools-for-ui) - Claude Code plugin for generating, comparing, and refining multiple UI variations in your codebase.
 - [Interface Design](https://github.com/Dammyjay93/interface-design?utm_source=awesome-ai-tools-for-ui) - Claude Code plugin for remembering interface decisions across sessions and keeping UI systems consistent.
+- [UIZZE](https://uizze.com/?view=agent&utm_source=github&utm_medium=directory&utm_campaign=github_awesome_ai_tools_for_ui_v1&utm_content=mcp_entry) - Helps Codex avoid generic AI UI by grounding it in real web and iOS references, with design-contract, validation, audit, and critique tools via MCP.
 
 ## Design Tools
 


### PR DESCRIPTION
## What changed

Adds UIZZE to the existing MCP Servers & Plugins section.

UIZZE gives Codex access to real web and iOS UI references plus design-contract, validation, audit, and critique tools through its hosted MCP server. The link uses source-specific attribution so UIZZE can measure whether this directory sends useful traffic.

Disclosure: I maintain UIZZE.

## Validation

- Confirmed the destination returns HTTP 200.
- Confirmed the listed capabilities in the public UIZZE MCP repository.
- Ran `git diff --check`.