### PR TITLE
Add Loupe (open-source local AI website builder, built on the Claude Agent SDK)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Know a cool tool that's not listed? [Create a PR](../../pulls) or [message me on
 - [Noyzzi](https://noyzzi.com/?utm_source=awesome-ai-tools-for-ui) - Growing collection of interactive designs with prompts you can copy and adapt.
 - [Design Resources for AI Agents](https://styles.refero.design/ai-agents/design-resources?utm_source=awesome-ai-tools-for-ui) - Curated directory of DESIGN.md resources and design references for AI agents.
 - [prompt-kit](https://www.prompt-kit.com/?utm_source=awesome-ai-tools-for-ui) - Accessible, customizable component primitives for AI interfaces, including prompt inputs, messages, reasoning, and tool views.
+- [Loupe](https://github.com/winchxyz/loupe?utm_source=awesome-ai-tools-for-ui) - Open-source, local AI website builder and design studio; AI agents build the site, you refine it visually on the live render, on your own keys.
 
 
 ## MCP Servers & Plugins


### PR DESCRIPTION
Adds [Loupe](https://github.com/winchxyz/loupe) to the **Apps** section. Loupe is an open-source, local Windows desktop app (Electron, built on the Claude Agent SDK) where AI agents build real websites and you refine them visually directly on the live render, with every edit verified against the real browser render — running on your own API keys (Anthropic/OpenAI/Gemini/xAI/OpenRouter) or existing Claude Code / Codex / Grok / Copilot subscription CLIs. MIT licensed and actively maintained (v0.1.1).

The entry follows the list format (hyphen separator, trailing period, `utm_source` param); I left the Tool Count badge untouched to keep the diff to one line — happy to bump it to 55 if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)