### PR TITLE
Add Markstream to Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Know a cool tool that's not listed? [Create a PR](../../pulls) or [message me on
 - [Noyzzi](https://noyzzi.com/?utm_source=awesome-ai-tools-for-ui) - Growing collection of interactive designs with prompts you can copy and adapt.
 - [Design Resources for AI Agents](https://styles.refero.design/ai-agents/design-resources?utm_source=awesome-ai-tools-for-ui) - Curated directory of DESIGN.md resources and design references for AI agents.
 - [prompt-kit](https://www.prompt-kit.com/?utm_source=awesome-ai-tools-for-ui) - Accessible, customizable component primitives for AI interfaces, including prompt inputs, messages, reasoning, and tool views.
+- [Markstream](https://markstream.simonhe.me/?utm_source=awesome-ai-tools-for-ui) - Open-source streaming Markdown renderer for AI chat interfaces, with Vue, React, Svelte, and Angular packages.
 
 
 ## MCP Servers & Plugins


### PR DESCRIPTION
## Summary

Adds Markstream next to the other building blocks for AI interfaces. Markstream progressively renders incomplete Markdown in streaming AI chat responses and provides packages for Vue, React, Svelte, and Angular.

## Why it fits

Like prompt-kit, Markstream helps developers build the output layer of an AI interface. It is open source, MIT licensed, documented, and actively maintained.

## Disclosure

I am the maintainer of Markstream. Thank you for considering it.

## Checks

- No existing Markstream entry, issue, or pull request was found.
- `git diff --check` passes.
- `awesome-lint` reports only existing repository-level requirements and an unrelated spelling warning; the new entry has no lint finding.