### PR TITLE
Add UIZZE anti-ui-slop Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Know a cool tool that's not listed? [Create a PR](../../pulls) or [message me on
 - [Nothing Design Skill](https://github.com/dominikmartn/nothing-design-skill?utm_source=awesome-ai-tools-for-ui) - Claude Code skill for producing Nothing-inspired monochrome, typographic, industrial UI.
 - [Hallmark](https://github.com/nutlope/hallmark?utm_source=awesome-ai-tools-for-ui) - Design skill for Claude Code, Cursor, and Codex that audits and generates UI against anti-slop design gates.
 - [Material Design 3 Skill](https://github.com/hamen/material-3-skill?utm_source=awesome-ai-tools-for-ui) - Portable Material Design 3 skill covering tokens, theming, 30+ components, responsive layout, and MD3 audits.
-- [UIZZE anti-ui-slop Skill](https://uizze.com/?utm_source=awesome-ai-tools-for-ui) - Free, installable Skill that stops coding agents from shipping generic UI with a design contract, real web and iOS screen evidence, required states, and a hard finish gate. The full UIZZE workflow searches 800,000+ real product screens. [Skill source and install instructions](https://uizze.com/.well-known/agent-skills/anti-ui-slop/SKILL.md?utm_source=awesome-ai-tools-for-ui).
+- [UIZZE anti-ui-slop Skill](https://uizze.com/ai-ui-slop?utm_source=awesome-ai-tools-for-ui) - Free MIT skill for coding agents with a design contract, required UI states, anti-slop review, and a hard finish gate. Optional [UIZZE](https://uizze.com/?utm_source=awesome-ai-tools-for-ui) workflow researches 800,000+ real web and iOS screens. [Skill source](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop?utm_source=awesome-ai-tools-for-ui).
 
 ## Apps
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Know a cool tool that's not listed? [Create a PR](../../pulls) or [message me on
 - [Nothing Design Skill](https://github.com/dominikmartn/nothing-design-skill?utm_source=awesome-ai-tools-for-ui) - Claude Code skill for producing Nothing-inspired monochrome, typographic, industrial UI.
 - [Hallmark](https://github.com/nutlope/hallmark?utm_source=awesome-ai-tools-for-ui) - Design skill for Claude Code, Cursor, and Codex that audits and generates UI against anti-slop design gates.
 - [Material Design 3 Skill](https://github.com/hamen/material-3-skill?utm_source=awesome-ai-tools-for-ui) - Portable Material Design 3 skill covering tokens, theming, 30+ components, responsive layout, and MD3 audits.
-- [UIZZE anti-ui-slop Skill](https://uizze.com/ai-ui-slop?utm_source=awesome-ai-tools-for-ui) - Free MIT skill for coding agents with a design contract, required UI states, anti-slop review, and a hard finish gate. Optional [UIZZE](https://uizze.com/?utm_source=awesome-ai-tools-for-ui) workflow researches 800,000+ real web and iOS screens. [Skill source](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop?utm_source=awesome-ai-tools-for-ui).
+- [UIZZE anti-ui-slop Skill](https://uizze.com/.well-known/agent-skills/anti-ui-slop/SKILL.md?utm_source=awesome-ai-tools-for-ui) - Free MIT Skill for coding agents with a design contract, required UI states, anti-slop review, and a hard finish gate. Optional authenticated [UIZZE MCP](https://uizze.com/docs?utm_source=awesome-ai-tools-for-ui) provides UI references and materials grounded in 800,000+ real web and iOS screens. [Skill source](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop?utm_source=awesome-ai-tools-for-ui).
 
 ## Apps
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Know a cool tool that's not listed? [Create a PR](../../pulls) or [message me on
 - [Nothing Design Skill](https://github.com/dominikmartn/nothing-design-skill?utm_source=awesome-ai-tools-for-ui) - Claude Code skill for producing Nothing-inspired monochrome, typographic, industrial UI.
 - [Hallmark](https://github.com/nutlope/hallmark?utm_source=awesome-ai-tools-for-ui) - Design skill for Claude Code, Cursor, and Codex that audits and generates UI against anti-slop design gates.
 - [Material Design 3 Skill](https://github.com/hamen/material-3-skill?utm_source=awesome-ai-tools-for-ui) - Portable Material Design 3 skill covering tokens, theming, 30+ components, responsive layout, and MD3 audits.
+- [UIZZE anti-ui-slop Skill](https://uizze.com/?utm_source=awesome-ai-tools-for-ui) - Free, installable Skill that stops coding agents from shipping generic UI with a design contract, real web and iOS screen evidence, required states, and a hard finish gate. The full UIZZE workflow searches 800,000+ real product screens. [Skill source and install instructions](https://uizze.com/.well-known/agent-skills/anti-ui-slop/SKILL.md?utm_source=awesome-ai-tools-for-ui).
 
 ## Apps
 


### PR DESCRIPTION
## What this adds

- Adds the UIZZE anti-ui-slop Skill to the existing Skills section.
- Links to the live, installable MIT Skill source and the public UIZZE workflow.
- Describes the free workflow accurately: design contracts, real web and iOS screen evidence, required states, and a hard finish gate.
- Keeps the full UIZZE distinction clear: the complete workflow searches 800,000+ real product screens.

The two linked UIZZE URLs were checked before submission and return HTTP 200. No generated files or dependencies are added.
